### PR TITLE
requestSpecの一部を削除

### DIFF
--- a/spec/requests/books_spec.rb
+++ b/spec/requests/books_spec.rb
@@ -40,13 +40,6 @@ RSpec.describe "/books", type: :request do
     end
   end
 
-  describe "GET /new" do
-    it "renders a successful response" do
-      get new_book_url
-      expect(response).to be_successful
-    end
-  end
-
   describe "GET /edit" do
     it "renders a successful response" do
       book = Book.create! valid_attributes


### PR DESCRIPTION
## 概要
テスト設定用のJavaScriptアセットを設定していないため、requsetSpecの一部が落ちていた。
今回はrequestSpecは用いないため、削除する方向で進める