### PR TITLE
DockerFileの権限変更を削除

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -72,12 +72,6 @@ FROM base
 COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
 COPY --from=build /rails /rails
 
-# Run and own only the runtime files as a non-root user for security
-RUN groupadd --system --gid 1000 rails && \
-    useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
-    chown -R rails:rails db log storage tmp
-USER 1000:1000
-
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 


### PR DESCRIPTION
## 概要
`docker compose run --rm web gem install rails`実行時に、ユーザー権限でエラーが発生したため、権限を変更