### PR TITLE
baseステージでパッケージを再度インストールするように修正

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,13 +1,6 @@
 # syntax=docker/dockerfile:1
 # check=error=true
 
-# This Dockerfile is designed for production, not development. Use with Kamal or build'n'run by hand:
-# docker build -t myapp .
-# docker run -d -p 80:80 -e RAILS_MASTER_KEY=<value from config/master.key> --name myapp myapp
-
-# For a containerized dev environment, see Dev Containers: https://guides.rubyonrails.org/getting_started_with_devcontainer.html
-
-# Make sure RUBY_VERSION matches the Ruby version in .ruby-version
 ARG RUBY_VERSION=3.3.6
 FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
 
@@ -20,10 +13,7 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment
-ENV RAILS_ENV="development" \
-    BUNDLE_DEPLOYMENT="1" \
-    BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development"
+ENV BUNDLE_PATH="/usr/local/bundle" 
 
 # Throw-away build stage to reduce size of final image
 FROM base AS build
@@ -64,9 +54,16 @@ RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
 RUN rm -rf node_modules
 
-
 # Final stage for app image
 FROM base
+
+# 開発環境用に必要なビルドツールを再度追加
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+    build-essential \
+    git \
+    libpq-dev && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Copy built artifacts: gems, application
 COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"


### PR DESCRIPTION
📝 自分用の備忘録としてメモしておきます
今回のエラーは、buildステージでinstallしたパッケージがbaseステージではinstallされていなかったため、エラーが発生しました。
マルチビルドは、buildステージとbaseステージを分けることにより、開発環境で必要なものと本番環境で必要なものを分けることにより、実行速度やメモリ量を減らせるメリットがある。

今回buildステージでは以下のパッケージをinstallしている
```
# Install application gems
COPY Gemfile Gemfile.lock ./
RUN bundle install && \
    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
    bundle exec bootsnap precompile --gemfile
```

その後、baseイメージを生成してbuildのファイル内容をコピーしているが、パッケージがコピーできていないため、互換性が合わず、エラーが発生した
```
FROM base
COPY --from=build
```
対処法
応急処置的な対応ではあるが、baseイメージを生成したあと再度同じパッケージをinstallすることで、互換性を合わせてエラーを解消
```
# Final stage for app image
FROM base

# 開発環境用に必要なビルドツールを再度追加
RUN apt-get update -qq && \
    apt-get install --no-install-recommends -y \
    build-essential \
    git \
    libpq-dev && \
    rm -rf /var/lib/apt/lists /var/cache/apt/archives
```