### PR TITLE
dbの永続化と2重でseedデータを送ってしまう仕組みの改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,10 @@ docker compose run --rm web gem install rails
 docker compose up -d
 ```
 
-### DB環境構築
+### seedデータの投入
 ```
-docker compose exec web rails db:create
-docker compose exec web rails db:migrate
 docker compose cp db/seeds.rb web:/rails/db/seeds.rb
 docker compose exec web rails db:seed
-```
-
-### tailswindcssのインストール
-```
-docker compose run --rm web rails javascript:install:esbuild
-docker compose run --rm web rails css:install:tailwind
-docker compose down
-docker compose build --no-cache
-docker compose up -d
 ```
 
 http://localhost:3000/books にアクセス

--- a/compose.yml
+++ b/compose.yml
@@ -6,7 +6,7 @@ services: # コンテナの定義開始
       TZ: Asia/Tokyo # タイムゾーンを日本に設定
       POSTGRES_PASSWORD: password # データベースのパスワード設定
     volumes: # データの永続化設定
-      - postgresql_data:/var/lib/postgresql # DBデータを永続化
+      - postgresql_data:/var/lib/postgresql/data # DBデータを永続化
     ports: # ポート設定
       - 5432:5432
     healthcheck: # コンテナの健康チェック設定
@@ -19,7 +19,7 @@ services: # コンテナの定義開始
     build: # Dockerイメージのビルド設定
       context: .  # ビルドコンテキストはカレントディレクトリ
       dockerfile: Dockerfile.dev # なんちゃって本番環境
-    command: bash -c "bundle install && bundle exec rails db:prepare && rm -f tmp/pids/server.pid && ./bin/dev"
+    command: bash -c "bundle install && bundle exec rails db:create db:migrate && rm -f tmp/pids/server.pid && ./bin/dev"
     # ↑ サーバー起動時のコマンド：
     # - bundle install: 必要なgemをインストール
     # - rails db:prepare: DBの準備


### PR DESCRIPTION
## 概要
dbのデータが永続化されていないことと、seedデータがcompose upするたびに作成されてしまう仕組みを改善。
本来なら、2つのPRで分けてだすんですけど、まあいいよねってことで一気に出します。すみません

### dbの永続化
データの永続化設定の指定パス先が異なっていたので、修正
✅ 実際にデータを作成して、`docker compose down`して、`docker compose up -d`しても残っていることを確認
<img width="1564" height="958" alt="image" src="https://github.com/user-attachments/assets/ab4fe2b4-8a76-42d4-a545-cd43a68310ba" />

### seedデータの冗長化
`rails db:prepare`というコマンドがseedデータの投入までやってくれる便利なコマンドらしい
ただ、今回は1回だけの実行にしたので、`db:create db:migrate`コマンドに修正して改善
databaseがup -dするたびに作ろうとしているのが、気になるが支障はなさそうなので、省きます
```
2025-08-12 18:29:16 web-1  | Bundle complete! 25 Gemfile dependencies, 132 gems now installed.
2025-08-12 18:29:16 web-1  | Bundled gems are installed into `/usr/local/bundle`
2025-08-12 18:29:16 web-1  | 1 installed gem you directly depend on is looking for funding.
2025-08-12 18:29:16 web-1  |   Run `bundle fund` for details
2025-08-12 18:29:16 db-1   | 2025-08-12 18:29:16.637 JST [41] ERROR:  database "myapp_development" already exists
2025-08-12 18:29:16 db-1   | 2025-08-12 18:29:16.637 JST [41] STATEMENT:  CREATE DATABASE "myapp_development" ENCODING = 'unicode' /*application='Myapp'*/
2025-08-12 18:29:16 web-1  | Database 'myapp_development' already exists
2025-08-12 18:29:16 db-1   | 2025-08-12 18:29:16.656 JST [42] ERROR:  database "myapp_test" already exists
2025-08-12 18:29:16 db-1   | 2025-08-12 18:29:16.656 JST [42] STATEMENT:  CREATE DATABASE "myapp_test" ENCODING = 'unicode' /*application='Myapp'*/
2025-08-12 18:29:16 web-1  | Database 'myapp_test' already exists
```
